### PR TITLE
Updated `cson-parser` from `^1.3.3` to `^4.0.9`

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,7 +6,8 @@
         "noEmit": false,
         "declaration": true,
         "emitDeclarationOnly": true,
-        "removeComments": false
+        "removeComments": false,
+        "newLine": "lf"
     },
     "files": [
         "index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,17 @@
       "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==",
       "dev": true
     },
-    "coffee-script": {
+    "coffeescript": {
       "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
     },
     "cson-parser": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
-      "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
+      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
       "requires": {
-        "coffee-script": "^1.10.0"
+        "coffeescript": "1.12.7"
       }
     },
     "fast-plist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,73 @@
 {
   "name": "vscode-grammar-updater",
   "version": "1.0.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-grammar-updater",
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "cson-parser": "^4.0.9",
+        "fast-plist": "0.1.2"
+      },
+      "bin": {
+        "vscode-grammar-updater": "bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^10.12.12",
+        "typescript": "^4.6.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "10.17.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==",
+      "dev": true
+    },
+    "node_modules/coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/cson-parser": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
+      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
+      "dependencies": {
+        "coffeescript": "1.12.7"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/fast-plist": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fast-plist/-/fast-plist-0.1.2.tgz",
+      "integrity": "sha1-pFr/NFGWAG1AbKbNzQX2kFHvNbg="
+    },
+    "node_modules/typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@types/node": {
       "version": "10.17.51",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-grammar-updater",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Utility to update TextMate grammars that are part of VSCode language extensions",
   "main": "./index.js",
   "bin": "./bin.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "fast-plist": "0.1.2",
-    "cson-parser": "^1.3.3"
+    "cson-parser": "^4.0.9"
   },
   "devDependencies": {
     "@types/node": "^10.12.12",


### PR DESCRIPTION
PR prompted by deprecation notice while using this package. Newer versions of `cson-parser` (specifically `3.0.0`) have addressed this.

```
 13:32:13 ❯ pnpm i   
Scope: all 7 workspace projects
packages/build-tools                     |  WARN  deprecated coffee-script@1.12.7
Packages: +1
+
Progress: resolved 364, reused 363, downloaded 1, added 1, done
```

Breaking changes in `cson-parser`:

* [`2.0.0`](https://github.com/groupon/cson-parser/releases/tag/v2.0.0) - Use single quotes by default in stringify. API not used by this package.
* [`3.0.0`](https://github.com/groupon/cson-parser/releases/tag/v3.0.0) - Now uses `coffeescript` instead of deprecated `coffee-script`.
   IMPORTANT: `coffee-script` and `coffeescript` provide a `bin` with the same name. As a consequence all downstream consumers (`cson-parser` and `vscode-grammar-updater`) inherit the potentially breaking change. This is only a problem if both CoffeeScript packages end up being installed after updating.
* [`4.0.0`](https://github.com/groupon/cson-parser/releases/tag/v4.0.0) - Minimum NodeJS version raised from `4.0.0` to `10.13` (technically performed over several releases under 4.0.x line).

Changes have been tested, though with a grammar source that lacks a `package.json` (which `vscode-grammer-updater` looks for by default).

```
 13:59:49 ❯ pnpm run update-grammar

> @ update-grammar /Users/jordan/source/git-ext
> node ./packages/build-tools/update-grammars.js

Reading from https://raw.githubusercontent.com/textmate/git.tmbundle/master/Syntaxes/Git%20Commit%20Message.tmLanguage
Reading from https://raw.githubusercontent.com/textmate/git.tmbundle/master/Syntaxes/Git%20Rebase%20Message.tmLanguage
Reading from https://raw.githubusercontent.com/textmate/diff.tmbundle/master/Syntaxes/Diff.plist
Updated git-rebase.tmLanguage.json to textmate/git.tmbundle@5870cf3 (2019-03-28)
Updated diff.tmLanguage.json to textmate/diff.tmbundle@0593bb7 (2017-01-09)
Updated git-commit.tmLanguage.json to textmate/git.tmbundle@93897a7 (2016-06-24)
Cannot get version. File does not exist at https://raw.githubusercontent.com/textmate/git.tmbundle/5870cf3f8abad3a6637bdf69250b5d2ded427dc4/package.json
```